### PR TITLE
[gh-8] Fixes for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
+    "cross-spawn": "^5.1.0",
     "fs-extra": "^4.0.1",
     "minimist": "^1.2.0",
     "rimraf": "^2.6.1",
-    "shell-escape": "^0.2.0",
     "tmp": "^0.0.31",
     "update-notifier": "^2.2.0"
   }

--- a/src/spawnSafe.ts
+++ b/src/spawnSafe.ts
@@ -1,0 +1,16 @@
+import { sync as spawnSync } from "cross-spawn"
+
+export default function spawnSafeSync(
+  command: string,
+  args?: string[],
+  options?: { noStderrOnError?: boolean; cwd?: string },
+) {
+  const result = spawnSync(command, args, options)
+  if (result.error || result.status !== 0) {
+    if (options && !options.noStderrOnError) {
+      console.error(result.stderr.toString())
+    }
+    throw result
+  }
+  return result
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,7 +612,7 @@ cross-spawn@^4.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
-cross-spawn@^5.0.1:
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -2559,10 +2559,6 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-
-shell-escape@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/shell-escape/-/shell-escape-0.2.0.tgz#68fd025eb0490b4f567a027f0bf22480b5f84133"
 
 shellwords@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
**Notes:**
* Updated to `cross-spawn`, based on https://github.com/xxorax/node-shell-escape/issues/9#issuecomment-261842878.
* Replaced `patch` with `git apply` — `patch` is not installed by default on Windows, while `git` is already used by this package.
* Tested make patch and it works properly on Windows
* Tested apply patch and it works properly on Windows