### PR TITLE
Use --no-ext-diff option when generating diffs

### DIFF
--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -155,6 +155,7 @@ export default function makePatch(
       "--cached",
       "--no-color",
       "--ignore-space-at-eol",
+      "--no-ext-diff"
     ]).stdout.toString()
 
     if (patch.trim() === "") {


### PR DESCRIPTION
I have git configured to use `patdiff`, an external tool, by default.
The resulting patches are useful for displaying them to a user, but they can't be applied