### PR TITLE
Improve patch speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "chalk": "^1.1.3",
     "cross-spawn": "^5.1.0",
     "fs-extra": "^4.0.1",
+    "klaw-sync": "^4.0.0",
     "minimist": "^1.2.0",
     "rimraf": "^2.6.2",
     "slash": "^1.0.0",

--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -133,7 +133,7 @@ export default function makePatch(
       )
 
     tmpExec("git", ["add", "-f", slash(path.join("node_modules", packageName))])
-    tmpExec("git", ["commit", "-m", "init"])
+    tmpExec("git", ["commit", "--allow-empty", "-m", "init"])
 
     // replace package with user's version
     rimraf.sync(tmpRepoPackagePath)

--- a/src/patch/reverse.ts
+++ b/src/patch/reverse.ts
@@ -44,41 +44,39 @@ function reverseHunks(hunks: PatchHunk[]): PatchHunk[] {
 
 export function reversePatch(patch: ParsedPatchFile): ParsedPatchFile {
   return patch
-    .map(
-      (part: PatchFilePart): PatchFilePart => {
-        switch (part.type) {
-          case "file creation":
-            return {
-              type: "file deletion",
-              path: part.path,
-              lines: part.lines,
-              mode: part.mode,
-              noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
-            }
-          case "file deletion":
-            return {
-              type: "file creation",
-              path: part.path,
-              lines: part.lines,
-              mode: part.mode,
-              noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
-            }
-          case "rename":
-            return {
-              type: "rename",
-              fromPath: part.toPath,
-              toPath: part.fromPath,
-            }
-          case "patch":
-            return {
-              type: "patch",
-              path: part.path,
-              parts: reverseHunks(part.parts),
-            }
-          default:
-            throw new Error()
-        }
-      },
-    )
+    .map((part: PatchFilePart): PatchFilePart => {
+      switch (part.type) {
+        case "file creation":
+          return {
+            type: "file deletion",
+            path: part.path,
+            lines: part.lines,
+            mode: part.mode,
+            noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
+          }
+        case "file deletion":
+          return {
+            type: "file creation",
+            path: part.path,
+            lines: part.lines,
+            mode: part.mode,
+            noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
+          }
+        case "rename":
+          return {
+            type: "rename",
+            fromPath: part.toPath,
+            toPath: part.fromPath,
+          }
+        case "patch":
+          return {
+            type: "patch",
+            path: part.path,
+            parts: reverseHunks(part.parts),
+          }
+        default:
+          throw new Error()
+      }
+    })
     .reverse()
 }

--- a/src/patch/reverse.ts
+++ b/src/patch/reverse.ts
@@ -44,39 +44,41 @@ function reverseHunks(hunks: PatchHunk[]): PatchHunk[] {
 
 export function reversePatch(patch: ParsedPatchFile): ParsedPatchFile {
   return patch
-    .map((part: PatchFilePart): PatchFilePart => {
-      switch (part.type) {
-        case "file creation":
-          return {
-            type: "file deletion",
-            path: part.path,
-            lines: part.lines,
-            mode: part.mode,
-            noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
-          }
-        case "file deletion":
-          return {
-            type: "file creation",
-            path: part.path,
-            lines: part.lines,
-            mode: part.mode,
-            noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
-          }
-        case "rename":
-          return {
-            type: "rename",
-            fromPath: part.toPath,
-            toPath: part.fromPath,
-          }
-        case "patch":
-          return {
-            type: "patch",
-            path: part.path,
-            parts: reverseHunks(part.parts),
-          }
-        default:
-          throw new Error()
-      }
-    })
+    .map(
+      (part: PatchFilePart): PatchFilePart => {
+        switch (part.type) {
+          case "file creation":
+            return {
+              type: "file deletion",
+              path: part.path,
+              lines: part.lines,
+              mode: part.mode,
+              noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
+            }
+          case "file deletion":
+            return {
+              type: "file creation",
+              path: part.path,
+              lines: part.lines,
+              mode: part.mode,
+              noNewlineAtEndOfFile: part.noNewlineAtEndOfFile,
+            }
+          case "rename":
+            return {
+              type: "rename",
+              fromPath: part.toPath,
+              toPath: part.fromPath,
+            }
+          case "patch":
+            return {
+              type: "patch",
+              path: part.path,
+              parts: reverseHunks(part.parts),
+            }
+          default:
+            throw new Error()
+        }
+      },
+    )
     .reverse()
 }

--- a/typings/klaw-sync.d.ts
+++ b/typings/klaw-sync.d.ts
@@ -1,0 +1,17 @@
+interface Options {
+  nodir?: boolean
+  nofile?: boolean
+  depthLimit?: number
+  fs?: object
+  filter?: (item: Item) => boolean
+}
+
+interface Item {
+  path: string
+  stats: object
+}
+
+declare module "klaw-sync" {
+  const klawSync: (dir: string, opts?: Options, ls?: Item[]) => Item[]
+  export = klawSync
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,6 +1949,12 @@ kind-of@^3.0.2:
   dependencies:
     is-buffer "^1.1.5"
 
+klaw-sync@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-4.0.0.tgz#7785692ea1a320ac3dda7a6c0c22b33a30aa3b3f"
+  dependencies:
+    graceful-fs "^4.1.11"
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"


### PR DESCRIPTION
Related to issue #60 

The idea is to apply the include/exclude filters earlier, so that only relevant files are ever touched (after the initial npm install). This avoids unnecessary copying, and it removes the need for the 1st diff pass (and ultimately the very expensive spawning of git reset).