### PR TITLE
Use named exports everywhere

### DIFF
--- a/integration-tests/newIntegrationTest.ts
+++ b/integration-tests/newIntegrationTest.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra"
 import * as path from "path"
-import spawnSafeSync from "../src/spawnSafe"
+import { spawnSafeSync } from "../src/spawnSafe"
 
 const testName = process.argv[2]
 

--- a/integration-tests/runIntegrationTest.ts
+++ b/integration-tests/runIntegrationTest.ts
@@ -1,9 +1,9 @@
 import * as fs from "fs-extra"
-import * as path from "../src/path"
+import { join, resolve } from "../src/path"
 import * as tmp from "tmp"
-import spawnSync from "../src/spawnSafe"
+import { spawnSafeSync } from "../src/spawnSafe"
 
-export const patchPackageTarballPath = path.resolve(
+export const patchPackageTarballPath = resolve(
   fs
     .readdirSync(".")
     .filter(nm => nm.match(/^patch-package\.test\.\d+\.tgz$/))[0],
@@ -15,14 +15,18 @@ export function runIntegrationTest(
 ) {
   describe(`Test ${projectName}:`, () => {
     const tmpDir = tmp.dirSync({ unsafeCleanup: true })
-    fs.copySync(path.join(__dirname, projectName), tmpDir.name, {
+    fs.copySync(join(__dirname, projectName), tmpDir.name, {
       recursive: true,
     })
 
-    const result = spawnSync(`./${projectName}.sh`, [patchPackageTarballPath], {
-      cwd: tmpDir.name,
-      throwOnError: false,
-    })
+    const result = spawnSafeSync(
+      `./${projectName}.sh`,
+      [patchPackageTarballPath],
+      {
+        cwd: tmpDir.name,
+        throwOnError: false,
+      },
+    )
 
     it("should exit with 0 status", () => {
       expect(result.status).toBe(0)

--- a/property-based-tests/executeTestCase.ts
+++ b/property-based-tests/executeTestCase.ts
@@ -2,7 +2,7 @@ import * as tmp from "tmp"
 import * as fs from "fs-extra"
 import * as path from "path"
 
-import spawnSafeSync from "../src/spawnSafe"
+import { spawnSafeSync } from "../src/spawnSafe"
 import { patch } from "../src/patch"
 import { executeEffects } from "../src/patch/apply"
 import { parsePatch } from "../src/patch/parse"

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -52,7 +52,10 @@ function getInstalledPackageVersion(
     .version as PackageVersion
 }
 
-export function applyPatchesForApp(appPath: AppPath, reverse: boolean): void {
+export const applyPatchesForApp = (
+  appPath: AppPath,
+  reverse: boolean,
+): void => {
   const patchesDirectory = path.join(appPath, "patches") as PatchesDirectory
   const files = findPatchFiles(patchesDirectory)
 
@@ -104,7 +107,10 @@ export function applyPatchesForApp(appPath: AppPath, reverse: boolean): void {
   })
 }
 
-export function applyPatch(patchFilePath: string, reverse: boolean): boolean {
+export const applyPatch = (
+  patchFilePath: string,
+  reverse: boolean,
+): boolean => {
   const patchFileContents = fs.readFileSync(patchFilePath).toString()
   try {
     const result = patch(patchFileContents, {

--- a/src/detectPackageManager.ts
+++ b/src/detectPackageManager.ts
@@ -1,43 +1,9 @@
 import * as fs from "fs"
-import * as path from "./path"
+import { join } from "./path"
 import * as chalk from "chalk"
 import * as process from "process"
 
 export type PackageManager = "yarn" | "npm" | "npm-shrinkwrap"
-
-export default function detectPackageManager(
-  appRootPath: string,
-  overridePackageManager: PackageManager | null,
-): PackageManager {
-  const packageLockExists = fs.existsSync(
-    path.join(appRootPath, "package-lock.json"),
-  )
-  const shrinkWrapExists = fs.existsSync(
-    path.join(appRootPath, "npm-shrinkwrap.json"),
-  )
-  const yarnLockExists = fs.existsSync(path.join(appRootPath, "yarn.lock"))
-  if ((packageLockExists || shrinkWrapExists) && yarnLockExists) {
-    if (overridePackageManager) {
-      return overridePackageManager
-    } else {
-      printSelectingDefaultMessage()
-      return shrinkWrapExists ? "npm-shrinkwrap" : "npm"
-    }
-  } else if (packageLockExists || shrinkWrapExists) {
-    if (overridePackageManager === "yarn") {
-      printNoYarnLockfileError()
-      process.exit(1)
-    } else {
-      return shrinkWrapExists ? "npm-shrinkwrap" : "npm"
-    }
-  } else if (yarnLockExists) {
-    return "yarn"
-  } else {
-    printNoLockfilesError()
-    process.exit(1)
-  }
-  throw Error()
-}
 
 function printNoYarnLockfileError() {
   console.error(`
@@ -68,4 +34,38 @@ You can override this setting by passing --use-yarn or deleting
 package-lock.json if you don't need it
 `,
   )
+}
+
+export const detectPackageManager = (
+  appRootPath: string,
+  overridePackageManager: PackageManager | null,
+): PackageManager => {
+  const packageLockExists = fs.existsSync(
+    join(appRootPath, "package-lock.json"),
+  )
+  const shrinkWrapExists = fs.existsSync(
+    join(appRootPath, "npm-shrinkwrap.json"),
+  )
+  const yarnLockExists = fs.existsSync(join(appRootPath, "yarn.lock"))
+  if ((packageLockExists || shrinkWrapExists) && yarnLockExists) {
+    if (overridePackageManager) {
+      return overridePackageManager
+    } else {
+      printSelectingDefaultMessage()
+      return shrinkWrapExists ? "npm-shrinkwrap" : "npm"
+    }
+  } else if (packageLockExists || shrinkWrapExists) {
+    if (overridePackageManager === "yarn") {
+      printNoYarnLockfileError()
+      process.exit(1)
+    } else {
+      return shrinkWrapExists ? "npm-shrinkwrap" : "npm"
+    }
+  } else if (yarnLockExists) {
+    return "yarn"
+  } else {
+    printNoLockfilesError()
+    process.exit(1)
+  }
+  throw Error()
 }

--- a/src/getAppRootPath.ts
+++ b/src/getAppRootPath.ts
@@ -1,12 +1,12 @@
 import * as fs from "fs"
-import * as path from "./path"
+import { join, resolve } from "./path"
 import * as process from "process"
 import { AppPath } from "./applyPatches"
 
-export default function getAppRootPath(): AppPath {
+export const getAppRootPath = (): AppPath => {
   let cwd = process.cwd()
-  while (!fs.existsSync(path.join(cwd, "package.json"))) {
-    cwd = path.resolve(cwd, "../")
+  while (!fs.existsSync(join(cwd, "package.json"))) {
+    cwd = resolve(cwd, "../")
   }
   return cwd as AppPath
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,10 @@ import * as process from "process"
 import * as minimist from "minimist"
 
 import { applyPatchesForApp } from "./applyPatches"
-import getAppRootPath from "./getAppRootPath"
-import makePatch from "./makePatch"
-import makeRegExp from "./makeRegExp"
-import detectPackageManager from "./detectPackageManager"
+import { getAppRootPath } from "./getAppRootPath"
+import { makePatch } from "./makePatch"
+import { makeRegExp } from "./makeRegExp"
+import { detectPackageManager } from "./detectPackageManager"
 
 const appPath = getAppRootPath()
 const argv = minimist(process.argv.slice(2), {

--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -137,10 +137,10 @@ export const makePatch = (
           !relativePath.match(includePaths) || relativePath.match(excludePaths),
       )
       .forEach(relativePath =>
-        fsExtra.removeSync(slash(path.join(tmpRepoPackagePath, relativePath))),
+        fsExtra.removeSync(slash(join(tmpRepoPackagePath, relativePath))),
       )
 
-    tmpExec("git", ["add", "-f", slash(path.join("node_modules", packageName))])
+    tmpExec("git", ["add", "-f", slash(join("node_modules", packageName))])
     tmpExec("git", ["commit", "--allow-empty", "-m", "init"])
 
     // replace package with user's version
@@ -154,8 +154,8 @@ export const makePatch = (
       )
       .forEach(relativePath =>
         fsExtra.copySync(
-          slash(path.join(packagePath, relativePath)),
-          slash(path.join(tmpRepoPackagePath, relativePath)),
+          slash(join(packagePath, relativePath)),
+          slash(join(tmpRepoPackagePath, relativePath)),
         ),
       )
 

--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -7,7 +7,7 @@ import {
   resolveRelativeFileDependenciesInPackageJson,
   resolveRelativeFileDependenciesInPackageLock,
 } from "./resolveRelativeFileDependencies"
-import spawnSafeSync from "./spawnSafe"
+import { spawnSafeSync } from "./spawnSafe"
 import { getPatchFiles } from "./patchFs"
 import * as fsExtra from "fs-extra"
 import { PackageManager } from "./detectPackageManager"

--- a/src/makeRegExp.ts
+++ b/src/makeRegExp.ts
@@ -1,11 +1,11 @@
 import { red } from "chalk"
 
-export default function makeRegExp(
+export const makeRegExp = (
   reString: string,
   name: string,
   defaultValue: RegExp,
   caseSensitive: boolean,
-): RegExp {
+): RegExp => {
   if (!reString) {
     return defaultValue
   } else {

--- a/src/patch/apply.ts
+++ b/src/patch/apply.ts
@@ -28,7 +28,7 @@ export type Effect =
       noNewlineAtEndOfFile: boolean
     }
 
-export function executeEffects(effects: Effect[]) {
+export const executeEffects = (effects: Effect[]) => {
   effects.forEach(eff => {
     switch (eff.type) {
       case "file deletion":
@@ -153,7 +153,7 @@ function applyPatch({ parts, path }: FilePatch): Effect {
   }
 }
 
-export function applyPatchFile(patch: ParsedPatchFile): Effect[] {
+export const applyPatchFile = (patch: ParsedPatchFile): Effect[] => {
   const effects: Effect[] = []
 
   for (const part of patch) {

--- a/src/patch/index.ts
+++ b/src/patch/index.ts
@@ -2,19 +2,19 @@ import { parsePatch } from "./parse"
 import { applyPatchFile, Effect } from "./apply"
 import { reversePatch } from "./reverse"
 
-export function patch(
+export const patch = (
   patchFileContents: string,
   {
     reverse = false,
   }: {
     reverse?: boolean
   } = {},
-): Effect[] {
-  let patch = parsePatch(patchFileContents)
+): Effect[] => {
+  let parsedPatch = parsePatch(patchFileContents)
 
   if (reverse) {
-    patch = reversePatch(patch)
+    parsedPatch = reversePatch(parsedPatch)
   }
 
-  return applyPatchFile(patch)
+  return applyPatchFile(parsedPatch)
 }

--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -10,7 +10,7 @@ interface HunkHeader {
   }
 }
 
-export function parseHunkHeaderLine(headerLine: string): HunkHeader {
+export const parseHunkHeaderLine = (headerLine: string): HunkHeader => {
   const match = headerLine
     .trim()
     .match(/^@@ -(\d+)(,(\d+))? \+(\d+)(,(\d+))? @@.*/)
@@ -383,6 +383,6 @@ class PatchParser {
   }
 }
 
-export function parsePatch(patchFileContents: string): ParsedPatchFile {
+export const parsePatch = (patchFileContents: string): ParsedPatchFile => {
   return new PatchParser(patchFileContents.split(/\n/)).parse()
 }

--- a/src/patch/reverse.ts
+++ b/src/patch/reverse.ts
@@ -42,7 +42,7 @@ function reverseHunks(hunks: PatchHunk[]): PatchHunk[] {
   return result
 }
 
-export function reversePatch(patch: ParsedPatchFile): ParsedPatchFile {
+export const reversePatch = (patch: ParsedPatchFile): ParsedPatchFile => {
   return patch
     .map((part: PatchFilePart): PatchFilePart => {
       switch (part.type) {

--- a/src/patchFs.ts
+++ b/src/patchFs.ts
@@ -19,7 +19,7 @@ function _getPatchFiles(
   return acc
 }
 
-export function getPatchFiles(patchesDir: string) {
+export const getPatchFiles = (patchesDir: string) => {
   return _getPatchFiles(patchesDir).filter(filename =>
     filename.match(/^.+(:|\+).+\.patch$/),
   )

--- a/src/patchFs.ts
+++ b/src/patchFs.ts
@@ -1,17 +1,17 @@
 import * as fs from "fs-extra"
-import * as path from "./path"
+import { join } from "./path"
 
 function _getPatchFiles(
   rootPatchesDir: string,
   scopedDir: string = "",
   acc: string[] = [],
 ) {
-  fs.readdirSync(path.join(rootPatchesDir, scopedDir)).forEach(filename => {
+  fs.readdirSync(join(rootPatchesDir, scopedDir)).forEach(filename => {
     if (filename.endsWith(".patch")) {
-      acc.push(path.join(scopedDir, filename))
+      acc.push(join(scopedDir, filename))
     } else if (
       filename.startsWith("@") &&
-      fs.statSync(path.join(rootPatchesDir, filename)).isDirectory()
+      fs.statSync(join(rootPatchesDir, filename)).isDirectory()
     ) {
       _getPatchFiles(rootPatchesDir, filename, acc)
     }

--- a/src/spawnSafe.ts
+++ b/src/spawnSafe.ts
@@ -12,11 +12,11 @@ const defaultOptions: SpawnSafeOptions = {
   throwOnError: true,
 }
 
-export default function spawnSafeSync(
+export const spawnSafeSync = (
   command: string,
   args?: string[],
   options?: SpawnSafeOptions,
-) {
+) => {
   const mergedOptions = Object.assign({}, defaultOptions, options)
   const result = spawnSync(command, args, options)
   if (result.error || result.status !== 0) {

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,8 @@
     "one-line": [false],
     "object-literal-sort-keys": [false],
     "no-trailing-whitespace": [false],
-    "object-literal-key-quotes": [false]
+    "object-literal-key-quotes": [false],
+    "no-default-export": true
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Instead of using `export default`, the code should use named exports everywhere. This improves readability and facilitates IDE support (e.g. navigating and refactoring).

Along the way, I rewrote most exported functions to nice fat-arrow functions