### PR TITLE
Ensure that directories are there when creating new files

### DIFF
--- a/src/patch/apply.ts
+++ b/src/patch/apply.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs-extra"
+import { dirname } from "path"
 import { ParsedPatchFile, FilePatch } from "./parse"
 
 export type Effect =
@@ -38,6 +39,7 @@ export const executeEffects = (effects: Effect[]) => {
         fs.moveSync(eff.fromPath, eff.toPath)
         break
       case "file creation":
+        fs.ensureDirSync(dirname(eff.path))
         fs.writeFileSync(
           eff.path,
           eff.lines.join("\n") + (eff.noNewlineAtEndOfFile ? "" : "\n"),


### PR DESCRIPTION
The logic for creating files when the dir does not exist fails silently. 
Using `fs.ensureDirSyc` we make sure that the dir tree is created prior to writing the file.