### PR TITLE
feature: add support for pnpm

### DIFF
--- a/src/detectPackageManager.ts
+++ b/src/detectPackageManager.ts
@@ -3,24 +3,32 @@ import { join } from "./path"
 import * as chalk from "chalk"
 import * as process from "process"
 
-export type PackageManager = "yarn" | "npm" | "npm-shrinkwrap"
+export type PackageManager = "yarn" | "npm" | "npm-shrinkwrap" | "pnpm"
 
 function printNoYarnLockfileError() {
   console.error(`
 ${chalk.red.bold("**ERROR**")} ${chalk.red(
-    `The --use-yarn option was specified but there is no yarn.lock file`,
-  )}
+      `The --use-yarn option was specified but there is no yarn.lock file`,
+    )}
+`)
+}
+
+function printNoPnpmLockfileError() {
+  console.error(`
+${chalk.red.bold("**ERROR**")} ${chalk.red(
+      `The --use-pnpm option was specified but there is no shrinkwrap.yaml file`,
+    )}
 `)
 }
 
 function printNoLockfilesError() {
   console.error(`
 ${chalk.red.bold("**ERROR**")} ${chalk.red(
-    `No package-lock.json, npm-shrinkwrap.json, or yarn.lock file.
+      `No package-lock.json, npm-shrinkwrap.json, or yarn.lock file.
 
 You must use either npm@>=5, yarn, or npm-shrinkwrap to manage this project's
 dependencies.`,
-  )}
+    )}
 `)
 }
 
@@ -46,8 +54,11 @@ export const detectPackageManager = (
   const shrinkWrapExists = fs.existsSync(
     join(appRootPath, "npm-shrinkwrap.json"),
   )
+  const shrinkWrapYamlExists = fs.existsSync(
+    join(appRootPath, "shrinkwrap.yaml"),
+  )
   const yarnLockExists = fs.existsSync(join(appRootPath, "yarn.lock"))
-  if ((packageLockExists || shrinkWrapExists) && yarnLockExists) {
+  if ((packageLockExists || shrinkWrapExists || shrinkWrapYamlExists) && yarnLockExists) {
     if (overridePackageManager) {
       return overridePackageManager
     } else {
@@ -58,11 +69,16 @@ export const detectPackageManager = (
     if (overridePackageManager === "yarn") {
       printNoYarnLockfileError()
       process.exit(1)
+    } else if (overridePackageManager === "pnpm") {
+      printNoPnpmLockfileError()
+      process.exit(1)
     } else {
       return shrinkWrapExists ? "npm-shrinkwrap" : "npm"
     }
   } else if (yarnLockExists) {
     return "yarn"
+  } else if (shrinkWrapYamlExists) {
+    return "pnpm"
   } else {
     printNoLockfilesError()
     process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { detectPackageManager } from "./detectPackageManager"
 
 const appPath = getAppRootPath()
 const argv = minimist(process.argv.slice(2), {
-  boolean: ["use-yarn", "case-sensitive-path-filtering", "reverse"],
+  boolean: ["use-yarn", "use-pnpm", "case-sensitive-path-filtering", "reverse"],
 })
 const packageNames = argv._
 
@@ -34,7 +34,7 @@ if (argv.help || argv.h) {
       makePatch(
         packageName,
         appPath,
-        detectPackageManager(appPath, argv["use-yarn"] ? "yarn" : null),
+        detectPackageManager(appPath, argv["use-yarn"] ? "yarn" : argv["use-pnpm"] ? "pnpm" : null),
         include,
         exclude,
       )
@@ -55,8 +55,8 @@ Usage:
     ${bold("patch-package")}
 
   Without arguments, the ${bold(
-    "patch-package",
-  )} command will attempt to find and apply
+      "patch-package",
+    )} command will attempt to find and apply
   patch files to your project. It looks for files named like
 
      ./patches/<package-name>+<version>.patch
@@ -67,15 +67,21 @@ Usage:
     ${bold("patch-package")} <package-name>${italic("[ <package-name>]")}
 
   When given package names as arguments, patch-package will create patch files
-  based on any changes you've made to the versions installed by yarn/npm.
+  based on any changes you've made to the versions installed by yarn/npm/pnpm.
 
   Options:
 
      ${bold("--use-yarn")}
 
-         By default, patch-package checks whether you use npm or yarn based on
-         which lockfile you have. If you have both, it uses npm by default.
+         By default, patch-package checks whether you use npm, yarn or pnpm based on
+         which lockfile you have. If you have all, it uses npm by default.
          Set this option to override that default and always use yarn.
+
+     ${bold("--use-pnpm")}
+
+         By default, patch-package checks whether you use npm, yarn or pnpm based on
+         which lockfile you have. If you have all, it uses npm by default.
+         Set this option to override that default and always use pnpm.
 
      ${bold("--exclude <regexp>")}
 

--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -104,6 +104,13 @@ export const makePatch = (
       )
       console.info(green("☑"), "Building clean node_modules with yarn")
       tmpExec(`yarn`)
+    } else if (packageManager === "pnpm") {
+      fsExtra.copySync(
+        join(appPath, "shrinkwrap.yaml"),
+        join(tmpRepo.name, "shrinkwrap.yaml"),
+      )
+      console.info(green("☑"), "Building clean node_modules with pnpm")
+      tmpExec("pnpm", ["i"])
     } else {
       const lockFileName =
         packageManager === "npm-shrinkwrap"


### PR DESCRIPTION
This adds support for @pnpm.

I had another change in the 5.x code where I had to add `dereference: true` to the `fsextra.copySync` calls to support symlinked directories.

@zkochan what do you think?