### PR TITLE
style: change warning color from red to yellow

### DIFF
--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -1,4 +1,4 @@
-import { bold, cyan, green, red } from "chalk"
+import { bold, cyan, green, red, yellow } from "chalk"
 import * as fs from "fs"
 import * as path from "path"
 import { getPatchFiles } from "./patchFs"
@@ -40,7 +40,7 @@ function getInstalledPackageVersion(
   const packageDir = path.join(appPath, "node_modules", packageName)
   if (!fs.existsSync(packageDir)) {
     console.warn(
-      `${red("Warning:")} Patch file found for package ${path.posix.basename(
+      `${yellow("Warning:")} Patch file found for package ${path.posix.basename(
         packageDir,
       )}` + ` which is not present at ${packageDir}`,
     )


### PR DESCRIPTION
Got a fright over a red colored warning, just after some yellow ones from a yarn install.

Warning: Patch file found for package aframe which is not present 
Since this message doesn't mean the install failed, can we color like how most other tooling color them?

Thanks for the project it has been working great :)