### PR TITLE
Handle CRLF line breaks in the patch parser

### DIFF
--- a/src/patch/__snapshots__/parse.test.ts.snap
+++ b/src/patch/__snapshots__/parse.test.ts.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`the patch parser can handle files with CRLF line breaks 1`] = `
+Array [
+  Object {
+    "lines": Array [
+      "this is a new file
+",
+    ],
+    "mode": 420,
+    "noNewlineAtEndOfFile": false,
+    "path": "banana.ts",
+    "type": "file creation",
+  },
+]
+`;
+
 exports[`the patch parser works for a simple case 1`] = `
 Array [
   Object {

--- a/src/patch/parse.test.ts
+++ b/src/patch/parse.test.ts
@@ -91,6 +91,15 @@ index 2de83dd..842652c 100644
  file
 `
 
+const crlfLineBreaks = `diff --git a/banana.ts b/banana.ts
+new file mode 100644
+index 0000000..3e1267f
+--- /dev/null
++++ b/banana.ts
+@@ -0,0 +1 @@
++this is a new file
+`.replace(/\n/g, "\r\n")
+
 describe("the patch parser", () => {
   it("works for a simple case", () => {
     expect(parsePatch(patch)).toMatchSnapshot()
@@ -104,5 +113,8 @@ describe("the patch parser", () => {
   })
   it("is OK when blank lines are accidentally created", () => {
     expect(parsePatch(accidentalBlankLine)).toEqual(parsePatch(patch))
+  })
+  it(`can handle files with CRLF line breaks`, () => {
+    expect(parsePatch(crlfLineBreaks)).toMatchSnapshot()
   })
 })

--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -266,7 +266,7 @@ class PatchParser {
   }
 
   private parseFileModification() {
-    const startPath = this.currentLine.slice("--- ".length)
+    const startPath = this.currentLine.trim().slice("--- ".length)
     this.nextLine()
     const endPath = this.currentLine.trim().slice("--- ".length)
     this.nextLine()


### PR DESCRIPTION
I noticed that if a patch file was checked out on Windows and it contained CRLF linebreaks, then `patch-package` would fail on file creation because this condition would be false due to `startPath` containing a trailing `\r` (carriage return) character: https://github.com/ds300/patch-package/blob/54a168b/src/patch/parse.ts#L297

After some investigation, it turned out that this was happening because https://github.com/ds300/patch-package/blob/54a168b/src/patch/parse.ts#L387 was splitting patch file contents on `\n` and so every line contained a trailing `\r`

~Interestingly, I couldn't get `yarn test --runInBand` to pass locally even on a fresh checkout (without my changes) 🙁~ Thanks to CI, I've now managed to ensure all tests pass.