### PR TITLE
Allow multiple hunks in patch parsing

### DIFF
--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -254,8 +254,8 @@ class PatchParser {
       return false
     }
     // Next hunk is starting
-    if (this.currentLine.startsWith('---')) {
-      return false;
+    if (this.currentLine.startsWith("---")) {
+      return false
     }
     switch (this.currentLine[0]) {
       case undefined:

--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -253,6 +253,10 @@ class PatchParser {
     if (this.isEOF) {
       return false
     }
+    // Next hunk is starting
+    if (this.currentLine.startsWith('---')) {
+      return false;
+    }
     switch (this.currentLine[0]) {
       case undefined:
       case " ":


### PR DESCRIPTION
Error: When patch files have multiple hunks. e.g.

```
--- a/node_modules/a
+++ b/node_modules/a
... some changes
--- a/node_modules/b
+++ b/node_modules/b
... some more changes
```

patch-package starts to include the markers for next lines into it's parser which obviously fails