### PR TITLE
Refactor to handle file modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "precommit": "tsc --noEmit && lint-staged",
     "prepublishOnly": "yarn run clean && yarn run build",
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "new-integration-test": "ts-node integration-tests/newIntegrationTest.ts",
     "clean": "rimraf dist patch-package.test*.tgz",
     "format": "prettier --no-semi --write --trailing-comma=all src{/**,}/*.ts",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier": "^1.15.3",
     "randomstring": "^1.1.5",
     "ts-jest": "^23.10.5",
-    "ts-node": "^7.0.1",
+    "ts-node": "6",
     "tslint": "^5.2.0",
     "typescript": "^3.2.2"
   },

--- a/property-based-tests/regressionTests.test.ts
+++ b/property-based-tests/regressionTests.test.ts
@@ -181,4 +181,16 @@ describe("regression tests", () => {
       modifiedFiles: { cpz: { contents: "E\n", mode: 420 } },
     })
   })
+
+  describe("18", () => {
+    executeTestCase({
+      cleanFiles: {},
+      modifiedFiles: {
+        ww: {
+          contents: "banana",
+          mode: 420,
+        },
+      },
+    })
+  })
 })

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from "fs-extra"
 import { join, resolve } from "./path"
 import { posix } from "path"
 import { getPackageDetailsFromPatchFilename } from "./PackageDetails"
-import { parsePatch } from "./patch/parse"
+import { parsePatchFile } from "./patch/parse"
 import { reversePatch } from "./patch/reverse"
 
 function findPatchFiles(patchesDirectory: string): string[] {
@@ -115,7 +115,7 @@ export const applyPatch = (
   reverse: boolean,
 ): boolean => {
   const patchFileContents = readFileSync(patchFilePath).toString()
-  const patch = parsePatch(patchFileContents)
+  const patch = parsePatchFile(patchFileContents)
   try {
     executeEffects(reverse ? reversePatch(patch) : patch, { dryRun: false })
   } catch (e) {

--- a/src/assertNever.ts
+++ b/src/assertNever.ts
@@ -1,0 +1,3 @@
+export function assertNever(x: never): never {
+  throw new Error("Unexpected object: " + x)
+}

--- a/src/patch/__snapshots__/parse.test.ts.snap
+++ b/src/patch/__snapshots__/parse.test.ts.snap
@@ -3,14 +3,211 @@
 exports[`the patch parser can handle files with CRLF line breaks 1`] = `
 Array [
   Object {
-    "lines": Array [
-      "this is a new file
+    "hash": "3e1267f",
+    "hunk": Object {
+      "header": Object {
+        "original": Object {
+          "length": 0,
+          "start": 1,
+        },
+        "patched": Object {
+          "length": 1,
+          "start": 1,
+        },
+      },
+      "parts": Array [
+        Object {
+          "lines": Array [
+            "this is a new file
 ",
-    ],
+          ],
+          "noNewlineAtEndOfFile": false,
+          "type": "insertion",
+        },
+      ],
+    },
     "mode": 420,
-    "noNewlineAtEndOfFile": false,
     "path": "banana.ts",
     "type": "file creation",
+  },
+]
+`;
+
+exports[`the patch parser works 1`] = `
+Array [
+  Object {
+    "fromPath": "numbers.txt",
+    "toPath": "banana.txt",
+    "type": "rename",
+  },
+  Object {
+    "newMode": 493,
+    "oldMode": 420,
+    "path": "banana.txt",
+    "type": "mode change",
+  },
+  Object {
+    "afterHash": "92d2c5f",
+    "beforeHash": "fbf1785",
+    "hunks": Array [
+      Object {
+        "header": Object {
+          "original": Object {
+            "length": 4,
+            "start": 1,
+          },
+          "patched": Object {
+            "length": 4,
+            "start": 1,
+          },
+        },
+        "parts": Array [
+          Object {
+            "lines": Array [
+              "one",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "deletion",
+          },
+          Object {
+            "lines": Array [
+              "ne",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "",
+              "two",
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+        ],
+      },
+    ],
+    "path": "banana.txt",
+    "type": "patch",
+  },
+]
+`;
+
+exports[`the patch parser works 2`] = `
+Array [
+  Object {
+    "afterHash": "842652c",
+    "beforeHash": "2de83dd",
+    "hunks": Array [
+      Object {
+        "header": Object {
+          "original": Object {
+            "length": 5,
+            "start": 1,
+          },
+          "patched": Object {
+            "length": 5,
+            "start": 1,
+          },
+        },
+        "parts": Array [
+          Object {
+            "lines": Array [
+              "this",
+              "is",
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+          Object {
+            "lines": Array [
+              "a",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "deletion",
+          },
+          Object {
+            "lines": Array [
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "file",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+        ],
+      },
+    ],
+    "path": "banana.ts",
+    "type": "patch",
+  },
+]
+`;
+
+exports[`the patch parser works 3`] = `
+Array [
+  Object {
+    "fromPath": "numbers.txt",
+    "toPath": "banana.txt",
+    "type": "rename",
+  },
+  Object {
+    "newMode": 493,
+    "oldMode": 420,
+    "path": "banana.txt",
+    "type": "mode change",
+  },
+  Object {
+    "afterHash": "92d2c5f",
+    "beforeHash": "fbf1785",
+    "hunks": Array [
+      Object {
+        "header": Object {
+          "original": Object {
+            "length": 4,
+            "start": 1,
+          },
+          "patched": Object {
+            "length": 4,
+            "start": 1,
+          },
+        },
+        "parts": Array [
+          Object {
+            "lines": Array [
+              "one",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "deletion",
+          },
+          Object {
+            "lines": Array [
+              "ne",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "",
+              "two",
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+        ],
+      },
+    ],
+    "path": "banana.txt",
+    "type": "patch",
   },
 ]
 `;
@@ -18,47 +215,52 @@ Array [
 exports[`the patch parser works for a simple case 1`] = `
 Array [
   Object {
-    "parts": Array [
+    "afterHash": "842652c",
+    "beforeHash": "2de83dd",
+    "hunks": Array [
       Object {
-        "original": Object {
-          "length": 5,
-          "start": 1,
+        "header": Object {
+          "original": Object {
+            "length": 5,
+            "start": 1,
+          },
+          "patched": Object {
+            "length": 5,
+            "start": 1,
+          },
         },
-        "patched": Object {
-          "length": 5,
-          "start": 1,
-        },
-        "type": "hunk header",
-      },
-      Object {
-        "lines": Array [
-          "this",
-          "is",
-          "",
+        "parts": Array [
+          Object {
+            "lines": Array [
+              "this",
+              "is",
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+          Object {
+            "lines": Array [
+              "a",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "deletion",
+          },
+          Object {
+            "lines": Array [
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "file",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
         ],
-        "noNewlineAtEndOfFile": false,
-        "type": "context",
-      },
-      Object {
-        "lines": Array [
-          "a",
-        ],
-        "noNewlineAtEndOfFile": false,
-        "type": "deletion",
-      },
-      Object {
-        "lines": Array [
-          "",
-        ],
-        "noNewlineAtEndOfFile": false,
-        "type": "insertion",
-      },
-      Object {
-        "lines": Array [
-          "file",
-        ],
-        "noNewlineAtEndOfFile": false,
-        "type": "context",
       },
     ],
     "path": "banana.ts",

--- a/src/patch/__snapshots__/parse.test.ts.snap
+++ b/src/patch/__snapshots__/parse.test.ts.snap
@@ -33,6 +33,141 @@ Array [
 ]
 `;
 
+exports[`the patch parser parses old-style patches 1`] = `
+Array [
+  Object {
+    "afterHash": null,
+    "beforeHash": null,
+    "hunks": Array [
+      Object {
+        "header": Object {
+          "original": Object {
+            "length": 10,
+            "start": 41,
+          },
+          "patched": Object {
+            "length": 11,
+            "start": 41,
+          },
+        },
+        "parts": Array [
+          Object {
+            "lines": Array [
+              " */",
+              "function isValidNameError(name, node) {",
+              "  !(typeof name === 'string') ? (0, _invariant2.default)(0, 'Expected string') : void 0;",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+          Object {
+            "lines": Array [
+              "  if (name.length > 1 && name[0] === '_' && name[1] === '_') {",
+              "    return new _GraphQLError.GraphQLError('Name \\"' + name + '\\" must not begin with \\"__\\", which is reserved by ' + 'GraphQL introspection.', node);",
+              "  }",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "deletion",
+          },
+          Object {
+            "lines": Array [
+              "  // if (name.length > 1 && name[0] === '_' && name[1] === '_') {",
+              "  //   return new _GraphQLError.GraphQLError('Name \\"' + name + '\\" must not begin with \\"__\\", which is reserved by ' + 'GraphQL introspection.', node);",
+              "  // }",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "  if (!NAME_RX.test(name)) {",
+              "    return new _GraphQLError.GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \\"' + name + '\\" does not.', node);",
+              "  }",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+          Object {
+            "lines": Array [
+              "",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "}",
+            ],
+            "noNewlineAtEndOfFile": true,
+            "type": "context",
+          },
+        ],
+      },
+    ],
+    "path": "node_modules/graphql/utilities/assertValidName.js",
+    "type": "patch",
+  },
+  Object {
+    "afterHash": null,
+    "beforeHash": null,
+    "hunks": Array [
+      Object {
+        "header": Object {
+          "original": Object {
+            "length": 9,
+            "start": 29,
+          },
+          "patched": Object {
+            "length": 9,
+            "start": 29,
+          },
+        },
+        "parts": Array [
+          Object {
+            "lines": Array [
+              " */",
+              "export function isValidNameError(name, node) {",
+              "  !(typeof name === 'string') ? invariant(0, 'Expected string') : void 0;",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+          Object {
+            "lines": Array [
+              "  if (name.length > 1 && name[0] === '_' && name[1] === '_') {",
+              "    return new GraphQLError('Name \\"' + name + '\\" must not begin with \\"__\\", which is reserved by ' + 'GraphQL introspection.', node);",
+              "  }",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "deletion",
+          },
+          Object {
+            "lines": Array [
+              "  // if (name.length > 1 && name[0] === '_' && name[1] === '_') {",
+              "  //   return new GraphQLError('Name \\"' + name + '\\" must not begin with \\"__\\", which is reserved by ' + 'GraphQL introspection.', node);",
+              "  // }",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "insertion",
+          },
+          Object {
+            "lines": Array [
+              "  if (!NAME_RX.test(name)) {",
+              "    return new GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but \\"' + name + '\\" does not.', node);",
+              "  }",
+            ],
+            "noNewlineAtEndOfFile": false,
+            "type": "context",
+          },
+        ],
+      },
+    ],
+    "path": "node_modules/graphql/utilities/assertValidName.mjs",
+    "type": "patch",
+  },
+]
+`;
+
 exports[`the patch parser works 1`] = `
 Array [
   Object {

--- a/src/patch/parse.test.ts
+++ b/src/patch/parse.test.ts
@@ -100,8 +100,7 @@ index 0000000..3e1267f
 +this is a new file
 `.replace(/\n/g, "\r\n")
 
-const modeChangeAndModifyAndRename = `
-diff --git a/numbers.txt b/banana.txt
+const modeChangeAndModifyAndRename = `diff --git a/numbers.txt b/banana.txt
 old mode 100644
 new mode 100755
 similarity index 96%
@@ -116,6 +115,42 @@ index fbf1785..92d2c5f
  
  two
  
+`
+
+const oldStylePatch = `patch-package
+--- a/node_modules/graphql/utilities/assertValidName.js
++++ b/node_modules/graphql/utilities/assertValidName.js
+@@ -41,10 +41,11 @@ function assertValidName(name) {
+  */
+ function isValidNameError(name, node) {
+   !(typeof name === 'string') ? (0, _invariant2.default)(0, 'Expected string') : void 0;
+-  if (name.length > 1 && name[0] === '_' && name[1] === '_') {
+-    return new _GraphQLError.GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
+-  }
++  // if (name.length > 1 && name[0] === '_' && name[1] === '_') {
++  //   return new _GraphQLError.GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
++  // }
+   if (!NAME_RX.test(name)) {
+     return new _GraphQLError.GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "' + name + '" does not.', node);
+   }
++
+ }
+\\ No newline at end of file
+--- a/node_modules/graphql/utilities/assertValidName.mjs
++++ b/node_modules/graphql/utilities/assertValidName.mjs
+@@ -29,9 +29,9 @@ export function assertValidName(name) {
+  */
+ export function isValidNameError(name, node) {
+   !(typeof name === 'string') ? invariant(0, 'Expected string') : void 0;
+-  if (name.length > 1 && name[0] === '_' && name[1] === '_') {
+-    return new GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
+-  }
++  // if (name.length > 1 && name[0] === '_' && name[1] === '_') {
++  //   return new GraphQLError('Name "' + name + '" must not begin with "__", which is reserved by ' + 'GraphQL introspection.', node);
++  // }
+   if (!NAME_RX.test(name)) {
+     return new GraphQLError('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "' + name + '" does not.', node);
+   }
 `
 
 describe("the patch parser", () => {
@@ -141,5 +176,9 @@ describe("the patch parser", () => {
 
     expect(parsePatchFile(accidentalBlankLine)).toMatchSnapshot()
     expect(parsePatchFile(modeChangeAndModifyAndRename)).toMatchSnapshot()
+  })
+
+  it.only("parses old-style patches", () => {
+    expect(parsePatchFile(oldStylePatch)).toMatchSnapshot()
   })
 })

--- a/src/patch/parse.test.ts
+++ b/src/patch/parse.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable
 
-import { parsePatch } from "../patch/parse"
+import { parsePatchFile } from "../patch/parse"
 
 const patch = `diff --git a/banana.ts b/banana.ts
 index 2de83dd..842652c 100644
@@ -100,21 +100,46 @@ index 0000000..3e1267f
 +this is a new file
 `.replace(/\n/g, "\r\n")
 
+const modeChangeAndModifyAndRename = `
+diff --git a/numbers.txt b/banana.txt
+old mode 100644
+new mode 100755
+similarity index 96%
+rename from numbers.txt
+rename to banana.txt
+index fbf1785..92d2c5f
+--- a/numbers.txt
++++ b/banana.txt
+@@ -1,4 +1,4 @@
+-one
++ne
+ 
+ two
+ 
+`
+
 describe("the patch parser", () => {
   it("works for a simple case", () => {
-    expect(parsePatch(patch)).toMatchSnapshot()
+    expect(parsePatchFile(patch)).toMatchSnapshot()
   })
   it("fails when the patch file has invalid headers", () => {
-    expect(() => parsePatch(invalidHeaders1)).toThrow()
-    expect(() => parsePatch(invalidHeaders2)).toThrow()
-    expect(() => parsePatch(invalidHeaders3)).toThrow()
-    expect(() => parsePatch(invalidHeaders4)).toThrow()
-    expect(() => parsePatch(invalidHeaders5)).toThrow()
+    expect(() => parsePatchFile(invalidHeaders1)).toThrow()
+    expect(() => parsePatchFile(invalidHeaders2)).toThrow()
+    expect(() => parsePatchFile(invalidHeaders3)).toThrow()
+    expect(() => parsePatchFile(invalidHeaders4)).toThrow()
+    expect(() => parsePatchFile(invalidHeaders5)).toThrow()
   })
   it("is OK when blank lines are accidentally created", () => {
-    expect(parsePatch(accidentalBlankLine)).toEqual(parsePatch(patch))
+    expect(parsePatchFile(accidentalBlankLine)).toEqual(parsePatchFile(patch))
   })
   it(`can handle files with CRLF line breaks`, () => {
-    expect(parsePatch(crlfLineBreaks)).toMatchSnapshot()
+    expect(parsePatchFile(crlfLineBreaks)).toMatchSnapshot()
+  })
+
+  it("works", () => {
+    expect(parsePatchFile(modeChangeAndModifyAndRename)).toMatchSnapshot()
+
+    expect(parsePatchFile(accidentalBlankLine)).toMatchSnapshot()
+    expect(parsePatchFile(modeChangeAndModifyAndRename)).toMatchSnapshot()
   })
 })

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["./property-based-tests"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,6 @@
     "noEmitOnError": false,
     "inlineSources": true
   },
-  "include": ["typings/**/*.d.ts", "src/**/*.ts"],
+  "include": ["typings/**/*.d.ts", "src/**/*.ts", "property-based-tests/**/*"],
   "compileOnSave": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4275,10 +4275,10 @@ ts-jest@^23.10.5:
     semver "^5.5"
     yargs-parser "10.x"
 
-ts-node@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
-  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
+ts-node@6:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.2.0.tgz#65a0ae2acce319ea4fd7ac8d7c9f1f90c5da6baf"
+  integrity sha512-ZNT+OEGfUNVMGkpIaDJJ44Zq3Yr0bkU/ugN1PHbU+/01Z7UV1fsELRiTx1KuQNvQ1A3pGh3y25iYF6jXgxV21A==
   dependencies:
     arrify "^1.0.0"
     buffer-from "^1.1.0"


### PR DESCRIPTION
re-wrote patch parsing for several reasons:

- improve code quality
- make it easier to support previous patch file format
- make it easier to support file mode changes

todo:

- [x] Integration tests for changing file modes