### PR TITLE
Fix: normalize version for npm ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/minimist": "^1.2.0",
     "@types/node": "^7.0.18",
     "@types/rimraf": "^0.0.28",
+    "@types/semver": "^5.5.0",
     "@types/tmp": "^0.0.33",
     "husky": "^0.13.3",
     "jest": "^23.6.0",
@@ -72,6 +73,7 @@
     "klaw-sync": "^4.0.0",
     "minimist": "^1.2.0",
     "rimraf": "^2.6.2",
+    "semver": "^5.6.0",
     "slash": "^1.0.0",
     "tmp": "^0.0.31",
     "update-notifier": "^2.4.0"

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -8,6 +8,7 @@ import { getPackageDetailsFromPatchFilename } from "./PackageDetails"
 import { parsePatchFile } from "./patch/parse"
 import { reversePatch } from "./patch/reverse"
 import isCi from "is-ci"
+import semver from "semver"
 
 // don't want to exit(1) on postinsall locally.
 // see https://github.com/ds300/patch-package/issues/86
@@ -41,7 +42,9 @@ function getInstalledPackageVersion({
     return null
   }
 
-  return require(join(packageDir, "package.json")).version
+  const { version } = require(join(packageDir, "package.json"))
+  // normalize version for `npm ci`
+  return semver.valid(version)
 }
 
 export const applyPatchesForApp = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,11 @@
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
 
+"@types/semver@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
+  integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
+
 "@types/tmp@^0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
@@ -3835,7 +3840,7 @@ semver-diff@^2.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@^5.5, semver@^5.5.0:
+semver@^5.5, semver@^5.5.0, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
`npm install` and creating a patch, then `npm ci` fails:
```
patch-package 6.0.2
Applying patches...

Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    google-closure-library@20190121.0.0

  applied to

    google-closure-library@v20190121.0.0
  
  At path
  
    node_modules/google-closure-library
```

[The original `version` of the package.json](https://github.com/google/closure-library/blob/d97e785fdf57de1f0f7b9aa9cd32df84bc53bc46/package.json#L4) is `v20190121.0.0`.

This issue is caused by difference between behavior of `npm install` and `npm ci`.
 `npm install` normalizes `version` in `package.json` of deps (`v20190121.0.0` is changed to `20190121.0.0`) but `npm ci` doesn't (just `v20190121.0.0`).

This PR normalizes the `version` with [`semver`](https://www.npmjs.com/package/semver).

repro: https://github.com/teppeis/closure-library.d.ts