### PR TITLE
test on NodeJS 12 and latest (currently 13)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  - "11"
+  - "12"
+  - "node"
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
This adds NodeJS 12 and current stable (13) to the test matrix and removes NodeJS 11 from it.