### PR TITLE
fix: change no patch files found error from red to bright blue

### DIFF
--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -97,7 +97,7 @@ export function applyPatchesForApp({
   const files = findPatchFiles(patchesDirectory)
 
   if (files.length === 0) {
-    console.error(chalk.red("No patch files found"))
+    console.error(chalk.blueBright("No patch files found"))
     return
   }
 


### PR DESCRIPTION
PR Contains:
- Changing "No Patch Files Found" error to fire from **red** to **bright blue**

Possible close for #145 