### PR TITLE
Ignore ".dev" suffix when deciding on package version mismatch

### DIFF
--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -149,7 +149,7 @@ export function applyPatchesForApp({
     ) {
       // yay patch was applied successfully
       // print warning if version mismatch
-      if (installedPackageVersion !== version) {
+      if (installedPackageVersion !== version.replace(/\.dev$/, "")) {
         printVersionMismatchWarning({
           packageName: name,
           actualVersion: installedPackageVersion,


### PR DESCRIPTION
> Do you have time/desire to try fixing that? No worries if not, I can get around to it this week.
> https://github.com/ds300/patch-package/pull/202#issuecomment-584048357

@ds300, I guess you haven't had the time either. :-) I am resubmitting that PR (not possible to reopen the old one because the branch was rebased) because my users are reporting [a problem (ENOENT)](balena-io/balena-cli/issues/1723) with the `update-notifier` dependency. I see this was solved in patch-package v6.2.1 by removing the dependency altogether (great!) but I am stuck at patch-package v6.1.x because of issue #201 which is "sufficiently resolved" by this PR, according to my testing. I understand it is not the perfect fix, but it also seems harmless and it solves my problem, so could we get this merged as it is and you can then do the better fix later on? :-) Thanks!