### PR TITLE
"--retry-on-clean" flag for re-applying patch if it could not be applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ team.
 
   Specify the name for the directory in which to put the patch files.
 
+- `--retry-on-clean`
+
+  If a patch fails to be applied even versions are correct. Then patch-package tries to 
+  apply the patch on the fresh new installed package.
+
 #### Nested packages
 
 If you are trying to patch a package at, e.g.

--- a/integration-tests/dev-only-patches/__snapshots__/dev-only-patches.test.ts.snap
+++ b/integration-tests/dev-only-patches/__snapshots__/dev-only-patches.test.ts.snap
@@ -1,11 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test dev-only-patches: fake-package should be skipped 1`] = `
+"SNAPSHOT: fake-package should be skipped
+patch-package 0.0.0
+Applying patches...
+Skipping dev-only fake-package@3.0.0.dev ✔
+left-pad@1.3.0 ✔
+Skipping dev-only slash@3.0.0 ✔
+END SNAPSHOT"
+`;
+
+exports[`Test dev-only-patches: patch-package fails to find fake-package 1`] = `
+"SNAPSHOT: patch-package fails to find fake-package
+Error: Patch file found for package fake-package which is not present at node_modules/fake-package
+
+  If this package is a dev dependency, rename the patch file to
+  
+    fake-package+3.0.0.dev.patch
+
+END SNAPSHOT"
+`;
+
 exports[`Test dev-only-patches: patch-package happily ignores slash because it's a dev dep 1`] = `
 "SNAPSHOT: patch-package happily ignores slash because it's a dev dep
 patch-package 0.0.0
 Applying patches...
-• Started patching the module left-pad
-• left-pad@1.3.0 patched .... ✔
+left-pad@1.3.0 ✔
 Skipping dev-only slash@3.0.0 ✔
 END SNAPSHOT"
 `;

--- a/integration-tests/dev-only-patches/__snapshots__/dev-only-patches.test.ts.snap
+++ b/integration-tests/dev-only-patches/__snapshots__/dev-only-patches.test.ts.snap
@@ -1,31 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test dev-only-patches: fake-package should be skipped 1`] = `
-"SNAPSHOT: fake-package should be skipped
-patch-package 0.0.0
-Applying patches...
-Skipping dev-only fake-package@3.0.0.dev ✔
-left-pad@1.3.0 ✔
-Skipping dev-only slash@3.0.0 ✔
-END SNAPSHOT"
-`;
-
-exports[`Test dev-only-patches: patch-package fails to find fake-package 1`] = `
-"SNAPSHOT: patch-package fails to find fake-package
-Error: Patch file found for package fake-package which is not present at node_modules/fake-package
-
-  If this package is a dev dependency, rename the patch file to
-  
-    fake-package+3.0.0.dev.patch
-
-END SNAPSHOT"
-`;
-
 exports[`Test dev-only-patches: patch-package happily ignores slash because it's a dev dep 1`] = `
 "SNAPSHOT: patch-package happily ignores slash because it's a dev dep
 patch-package 0.0.0
 Applying patches...
-left-pad@1.3.0 ✔
+• Started patching the module left-pad
+• left-pad@1.3.0 patched .... ✔
 Skipping dev-only slash@3.0.0 ✔
 END SNAPSHOT"
 `;

--- a/integration-tests/dev-only-patches/__snapshots__/dev-only-patches.test.ts.snap
+++ b/integration-tests/dev-only-patches/__snapshots__/dev-only-patches.test.ts.snap
@@ -5,7 +5,8 @@ exports[`Test dev-only-patches: fake-package should be skipped 1`] = `
 patch-package 0.0.0
 Applying patches...
 Skipping dev-only fake-package@3.0.0.dev ✔
-left-pad@1.3.0 ✔
+• Started patching the module left-pad
+• left-pad@1.3.0 patched .... ✔
 Skipping dev-only slash@3.0.0 ✔
 END SNAPSHOT"
 `;
@@ -25,7 +26,8 @@ exports[`Test dev-only-patches: patch-package happily ignores slash because it's
 "SNAPSHOT: patch-package happily ignores slash because it's a dev dep
 patch-package 0.0.0
 Applying patches...
-left-pad@1.3.0 ✔
+• Started patching the module left-pad
+• left-pad@1.3.0 patched .... ✔
 Skipping dev-only slash@3.0.0 ✔
 END SNAPSHOT"
 `;

--- a/integration-tests/ignores-scripts-when-making-patch/__snapshots__/ignores-scripts-when-making-patch.test.ts.snap
+++ b/integration-tests/ignores-scripts-when-making-patch/__snapshots__/ignores-scripts-when-making-patch.test.ts.snap
@@ -27,15 +27,5 @@ END SNAPSHOT"
 
 exports[`Test ignores-scripts-when-making-patch: there should be no stderr 1`] = `
 "SNAPSHOT: there should be no stderr
-warning package.json: No license field
-warning No license field
-error /private/var/folders/7p/d6qsgxp949vdkmv5trtclj_m0000gn/T/tmp-50009ckTOw9Yy8nRH/node_modules/naughty-package: Command failed.
-Exit code: 1
-Command: ./postinstall.sh
-Arguments: 
-Directory: /private/var/folders/7p/d6qsgxp949vdkmv5trtclj_m0000gn/T/tmp-50009ckTOw9Yy8nRH/node_modules/naughty-package
-Output:
-ls: ../patch-package: No such file or directory
-
 END SNAPSHOT"
 `;

--- a/integration-tests/ignores-scripts-when-making-patch/__snapshots__/ignores-scripts-when-making-patch.test.ts.snap
+++ b/integration-tests/ignores-scripts-when-making-patch/__snapshots__/ignores-scripts-when-making-patch.test.ts.snap
@@ -27,5 +27,15 @@ END SNAPSHOT"
 
 exports[`Test ignores-scripts-when-making-patch: there should be no stderr 1`] = `
 "SNAPSHOT: there should be no stderr
+warning package.json: No license field
+warning No license field
+error /private/var/folders/7p/d6qsgxp949vdkmv5trtclj_m0000gn/T/tmp-50009ckTOw9Yy8nRH/node_modules/naughty-package: Command failed.
+Exit code: 1
+Command: ./postinstall.sh
+Arguments: 
+Directory: /private/var/folders/7p/d6qsgxp949vdkmv5trtclj_m0000gn/T/tmp-50009ckTOw9Yy8nRH/node_modules/naughty-package
+Output:
+ls: ../patch-package: No such file or directory
+
 END SNAPSHOT"
 `;

--- a/integration-tests/nested-packages/__snapshots__/nested-packages.test.ts.snap
+++ b/integration-tests/nested-packages/__snapshots__/nested-packages.test.ts.snap
@@ -14,7 +14,8 @@ exports[`Test nested-packages: run patch-package 1`] = `
 "SNAPSHOT: run patch-package
 patch-package 0.0.0
 Applying patches...
-wrap-ansi/string-width@2.1.1 ✔
+• Started patching the module string-width
+• wrap-ansi/string-width@2.1.1 patched .... ✔
 END SNAPSHOT"
 `;
 

--- a/integration-tests/nested-packages/__snapshots__/nested-packages.test.ts.snap
+++ b/integration-tests/nested-packages/__snapshots__/nested-packages.test.ts.snap
@@ -14,8 +14,7 @@ exports[`Test nested-packages: run patch-package 1`] = `
 "SNAPSHOT: run patch-package
 patch-package 0.0.0
 Applying patches...
-• Started patching the module string-width
-• wrap-ansi/string-width@2.1.1 patched .... ✔
+wrap-ansi/string-width@2.1.1 ✔
 END SNAPSHOT"
 `;
 

--- a/integration-tests/nested-scoped-packages/__snapshots__/nested-scoped-packages.test.ts.snap
+++ b/integration-tests/nested-scoped-packages/__snapshots__/nested-scoped-packages.test.ts.snap
@@ -14,6 +14,7 @@ exports[`Test nested-scoped-packages: run patch-package 1`] = `
 "SNAPSHOT: run patch-package
 patch-package 0.0.0
 Applying patches...
-@microsoft/mezzurite-core/@types/angular@1.6.53 ✔
+• Started patching the module @types/angular
+• @microsoft/mezzurite-core/@types/angular@1.6.53 patched .... ✔
 END SNAPSHOT"
 `;

--- a/integration-tests/nested-scoped-packages/__snapshots__/nested-scoped-packages.test.ts.snap
+++ b/integration-tests/nested-scoped-packages/__snapshots__/nested-scoped-packages.test.ts.snap
@@ -14,7 +14,6 @@ exports[`Test nested-scoped-packages: run patch-package 1`] = `
 "SNAPSHOT: run patch-package
 patch-package 0.0.0
 Applying patches...
-• Started patching the module @types/angular
-• @microsoft/mezzurite-core/@types/angular@1.6.53 patched .... ✔
+@microsoft/mezzurite-core/@types/angular@1.6.53 ✔
 END SNAPSHOT"
 `;

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -420,7 +420,7 @@ function printTryingPatchOnClean({ packageName }: { packageName: string }) {
   console.warn(`${chalk.redBright("•")} ${chalk.redBright("**WARNING**")} 
     Patch could not be applied on package ${packageName}. 
     ${chalk.green("But good news:")} 
-    trying to re-apply the patch on a clean freshly downloaded package`)
+    Trying to re-apply the patch on a clean freshly downloaded package`)
 }
 
 function printVersionMismatchWarning({

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -88,11 +88,19 @@ export function applyPatchesForApp({
   appPath,
   reverse,
   patchDir,
+  retryOnClean,
 }: {
   appPath: string
   reverse: boolean
   patchDir: string
+  retryOnClean: boolean
 }): void {
+  if (retryOnClean) {
+    console.log(
+      "Removing lint error. This log will be removed in the next commit",
+    )
+  }
+
   const patchesDirectory = join(appPath, patchDir)
   const files = findPatchFiles(patchesDirectory)
 

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -20,6 +20,13 @@ const shouldExitPostinstallWithError = isCi || process.env.NODE_ENV === "test"
 
 const exit = () => process.exit(shouldExitPostinstallWithError ? 1 : 0)
 
+export type PatchingProgress =
+  | "creating_temp_folder"
+  | "installing"
+  | "copying"
+  | "patching"
+  | "complete"
+
 function findPatchFiles(patchesDirectory: string): string[] {
   if (!existsSync(patchesDirectory)) {
     return []
@@ -219,6 +226,63 @@ export function applyPatch({
   }
 
   return true
+}
+
+export function printPatchingProgress({
+  progress,
+  packageName,
+  packageVersion,
+  packagePathSpecifier,
+  copySrcDir,
+  copyDstDir,
+}: {
+  progress: PatchingProgress
+  packageName?: string
+  packageVersion?: string
+  packagePathSpecifier?: string
+  copySrcDir?: string
+  copyDstDir?: string
+}) {
+  switch (progress) {
+    case "creating_temp_folder":
+      console.info(chalk.green("•"), "Creating temporary folder")
+      break
+
+    case "installing":
+      console.info(
+        chalk.green("•"),
+        `Installing ${packageName}@${packageVersion} with yarn`,
+      )
+      break
+
+    case "copying":
+      const srcDir = copySrcDir ? copySrcDir : "<no source dir>"
+      const dstDit = copyDstDir ? copyDstDir : "<no destination dir>"
+
+      console.info(
+        chalk.green("•"),
+        `Copying clean package to apply a patch from
+          ${chalk.yellow(srcDir)} 
+        to
+          ${chalk.yellow(dstDit)}`,
+      )
+      break
+
+    case "patching":
+      const name = packageName ? packageName : ""
+      console.info(chalk.green("•"), `Started patching the module ${name}`)
+      break
+
+    case "complete":
+      const pathSpecifier = packagePathSpecifier ? packagePathSpecifier : ""
+      console.info(
+        chalk.green("•"),
+        `${chalk.bold(
+          pathSpecifier,
+        )}@${packageVersion} patched .... ${chalk.green("✔")}`,
+      )
+      break
+  }
 }
 
 function printVersionMismatchWarning({

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const argv = minimist(process.argv.slice(2), {
     "reverse",
     "help",
     "version",
+    "retry-on-clean",
   ],
   string: ["patch-dir"],
 })
@@ -69,7 +70,8 @@ if (argv.version || argv.v) {
   } else {
     console.log("Applying patches...")
     const reverse = !!argv["reverse"]
-    applyPatchesForApp({ appPath, reverse, patchDir })
+    const retryOnClean = !!argv["retry-on-clean"]
+    applyPatchesForApp({ appPath, reverse, patchDir, retryOnClean })
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,5 +124,10 @@ Usage:
      ${chalk.bold("--case-sensitive-path-filtering")}
 
          Make regexps used in --include or --exclude filters case-sensitive.
+         
+     ${chalk.bold("--retry-on-clean")}
+     
+        If a patch fails to be applied even versions are correct. Then patch-package tries to 
+        apply the patch on the fresh new installed package.
 `)
 }


### PR DESCRIPTION
If you are delivering your work continuously as a patch into an existing package then after applying `patch1` and trying to apply `patch2` patch-package fails (screenshot1).

`--retry-on-clean` flag tells patch-package if patch and package version are same but patch could not be applied then the flag tells patch-package to reapply patch again but on top of freshly installed dependency from NPM.


screenshot1 - previous state when patch-package failed
screenshot2 - if patch was applied without any problem
screenshot3 - if `--retry-on-clean` flag is present


screenshot1
<img width="701" alt="previous" src="https://user-images.githubusercontent.com/5796382/80503824-52634e80-896a-11ea-854f-16bbdd687c28.png">

screenshot2
<img width="612" alt="success1" src="https://user-images.githubusercontent.com/5796382/80503863-5d1de380-896a-11ea-9ebc-74279bfb6285.png">

screenshot3
<img width="789" alt="success2" src="https://user-images.githubusercontent.com/5796382/80503881-61e29780-896a-11ea-812f-1c0eedc0e3bd.png">


