### PR TITLE
update(getPackageResolution) take in to account non-standard versioning on Yarn lockfiles

### DIFF
--- a/src/getPackageResolution.ts
+++ b/src/getPackageResolution.ts
@@ -37,9 +37,14 @@ export function getPackageResolution({
     )).version as string
 
     const entries = Object.entries(appLockFile.object).filter(
-      ([k, v]) =>
-        k.startsWith(packageDetails.name + "@") &&
-        v.version === installedVersion,
+      ([pkgNameAndVersion, v]) => {
+        if (pkgNameAndVersion.startsWith(packageDetails.name + "@") && v.version === installedVersion) {
+            return true
+        }        
+        // Non-standard versioning. Yarn resolves "package@1.2.3+3d74b79d" as version "1.2.3"
+        // while installedVersion (from package.json) is "1.2.3+3d74b79d"
+        return pkgNameAndVersion === packageDetails.name + "@" + installedVersion;
+      }
     )
 
     const resolutions = entries.map(([_, v]) => {


### PR DESCRIPTION
Some packages tend to use non-standard versioning in their package.json files (e.g. commit hashes in the case of react-scripts@4.0.0-next.77+3d74b79d).

Currently, manually installing `react-scripts@4.0.0-next.77+3d74b79d` and then running `yarn patch-package react-scripts` will result in the error `Can't find lockfile entry for react-scripts`. This change should fix this issue.