### PR TITLE
fix: not remove `.git` from `tmpRepoPackagePath` when creating patches

### DIFF
--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -186,7 +186,7 @@ export function makePatch({
     // remove nested node_modules just to be safe
     rimraf(join(tmpRepoPackagePath, "node_modules"))
     // remove .git just to be safe
-    rimraf(join(tmpRepoPackagePath, "node_modules"))
+    rimraf(join(tmpRepoPackagePath, ".git"))
 
     // also remove ignored files like before
     removeIgnoredFiles(tmpRepoPackagePath, includePaths, excludePaths)


### PR DESCRIPTION
Fixes #257.