### PR TITLE
update README stating this is technique is not safe for publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="https://ds300.github.io/patch-package/patch-package.svg" width="80%" alt="patch-package" />
 </p>
 
+**Note: It is not safe to publish npm packages with patched dependencies!**
+
 `patch-package` lets app authors instantly make and keep fixes to npm
 dependencies. It's a vital band-aid for those of us living on the bleeding edge.
 


### PR DESCRIPTION
Per https://github.com/ds300/patch-package/issues/84, it is not safe to publish npm packages with patched dependencies. This notice should be prominent in patch-package documentation.