### PR TITLE
Sanitize package versions that contains metadata

### DIFF
--- a/src/getPackageResolution.ts
+++ b/src/getPackageResolution.ts
@@ -5,6 +5,9 @@ import { readFileSync, existsSync } from "fs-extra"
 import { parse as parseYarnLockFile } from "@yarnpkg/lockfile"
 import findWorkspaceRoot from "find-yarn-workspace-root"
 
+const sanitizeVersion = (version: string): string =>
+  version.replace(/\+.+$/, "")
+
 export function getPackageResolution({
   packageDetails,
   packageManager,
@@ -31,10 +34,10 @@ export function getPackageResolution({
       throw new Error("Can't parse lock file")
     }
 
-    const installedVersion = require(join(
-      resolve(appPath, packageDetails.path),
-      "package.json",
-    )).version as string
+    const installedVersion = sanitizeVersion(
+      require(join(resolve(appPath, packageDetails.path), "package.json"))
+        .version,
+    )
 
     const entries = Object.entries(appLockFile.object).filter(
       ([k, v]) =>


### PR DESCRIPTION
In [semver's summary](https://semver.org/#summary) we can find that:
> Additional labels for pre-release and **build metadata** are available as extensions to the MAJOR.MINOR.PATCH format.

Later on, they describe what that build metadata is: https://semver.org/#spec-item-10

This is the first time that I've seen this in the wild but it seems that [some packages](https://browse.unpkg.com/browse/@react-aria/focus@3.0.0-nightly.849/package.json) are using that and I actually had a need to patch such a package 😅 

My `yarn.lock` for this items looks this:
```
"@react-aria/focus@3.0.0-nightly.849", "@react-aria/focus@3.0.0-nightly.849+e08af810":
  version "3.0.0-nightly.849"
  resolved "https://registry.npmjs.org/@react-aria/focus/-/focus-3.0.0-nightly.849.tgz#a0f9147d695b78a18a86ef0d9c115340c6285c3c"
  integrity sha512-n9rfcn5jUOkIjnJo9gdOZW5wusT8YpsvfFWucQle4guiMsXtCRaE0tzsaZwFV9is8qEC8QZUWXfo3rbbqLuPrw==
  dependencies:
    "@babel/runtime" "^7.6.2"
    "@react-aria/interactions" "3.0.0-nightly.849+e08af810"
    "@react-aria/utils" "3.0.0-nightly.849+e08af810"
    "@react-types/shared" "3.0.0-nightly.849+e08af810"
    clsx "^1.1.1"
```

And the `.version` that I'm sanitizing as part of this PR is coming from the actual `package.json` file - so it contains that build metadata.

I'd like to write tests for this but I see that you are using property testing and while I know about the concept I've never actually written any such test. I'm eager to learn but would love some guidance - what would be the best place to add it? Any other tips?