### PR TITLE
fix Patch file parse error in windows

### DIFF
--- a/src/patch/parse.ts
+++ b/src/patch/parse.ts
@@ -142,6 +142,7 @@ const hunkLinetypes: {
   "\\": "pragma",
   // Treat blank lines as context
   undefined: "context",
+  "\r": "context",
 }
 
 function parsePatchLines(


### PR DESCRIPTION
fix new line for windows.
fix issue for: #191,  #207,  #266, #268,
maybe also for: #236, #244, #280

in windows, the line break is "\r\n". (while it is "\n" in Linux/Unix).
so after [split by "\n"](https://github.com/ds300/patch-package/blob/master/src/patch/parse.ts#L409), 
then [first char of blank line](https://github.com/ds300/patch-package/blob/master/src/patch/parse.ts#L228) will be "\r" for window.

so "Treat blank lines as context" should include "\r".