### PR TITLE
Update package.json's `files` list to omit test files and to fix sourcemap-debugging issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
   "files": [
     "index.js",
     "dist/**/*.js",
+    "!dist/**/*.test.js",
+    "src/**/*.ts",
+    "!src/**/*.test.ts",
     "CHANGELOG.md",
     "LICENSE",
     "patch-package-banner.png",


### PR DESCRIPTION
Updates package.json to:
* Include `src` which enables setting breakpoints in patch-package code when it's not running, and enables you to navigate from breakpoints in VSCode to the corresponding source line that's pointed to by the inline sourcemap. Also prevents an annoyance where every time I debug into patch-package code, VSCode prompts me for the directory location of the corresponding TS source file (which I can't provide because it's not installed).
* Exclude `*.test.js` and *.test.ts files that shouldn't be installed via `npm install` or `yarn add` because these are test-only files.

I tested this config using `npm pack` and the results are as expected: test files are missing and src files are present.