### PR TITLE
coercing semantic package version while searching lockfile entries in yarn.lock

### DIFF
--- a/src/coerceSemVer.ts
+++ b/src/coerceSemVer.ts
@@ -1,0 +1,5 @@
+import semver from "semver"
+
+export function coerceSemVer(version: string): string | null {
+  return semver.coerce(version)?.version || null
+}

--- a/src/getPackageResolution.ts
+++ b/src/getPackageResolution.ts
@@ -6,6 +6,7 @@ import { parse as parseYarnLockFile } from "@yarnpkg/lockfile"
 import yaml from "yaml"
 import findWorkspaceRoot from "find-yarn-workspace-root"
 import { getPackageVersion } from "./getPackageVersion"
+import { coerceSemVer } from "./coerceSemVer"
 
 export function getPackageResolution({
   packageDetails,
@@ -54,7 +55,7 @@ export function getPackageResolution({
       ([k, v]) =>
         k.startsWith(packageDetails.name + "@") &&
         // @ts-ignore
-        v.version === installedVersion,
+        coerceSemVer(v.version) === coerceSemVer(installedVersion),
     )
 
     const resolutions = entries.map(([_, v]) => {


### PR DESCRIPTION
fixing issue:
https://github.com/ds300/patch-package/issues/360