### PR TITLE
Bump Chalk to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "David Sheldrick",
   "license": "MIT",
   "engines": {
+    "node": ">=10",
     "npm": ">5"
   },
   "bin": {
@@ -72,7 +73,7 @@
   },
   "dependencies": {
     "@yarnpkg/lockfile": "^1.1.0",
-    "chalk": "^2.4.2",
+    "chalk": "^4.1.2",
     "cross-spawn": "^6.0.5",
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,6 +1085,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"


### PR DESCRIPTION
https://github.com/chalk/chalk/releases/tag/v3.0.0
https://github.com/chalk/chalk/releases/tag/v4.0.0

The main change is that it now requires Node 10. As of January 1st 2020
this is the oldest supported node version, so that should be safe by now.