### PR TITLE
fix excludePaths: exclude only package.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ if (argv.version || argv.v) {
     const excludePaths = makeRegExp(
       argv.exclude,
       "exclude",
-      /package\.json$/,
+      /^package\.json$/,
       argv["case-sensitive-path-filtering"],
     )
     const packageManager = detectPackageManager(


### PR DESCRIPTION
before this, also `some-package.json` and `path/to/package.json` were excluded

we want to exlclude only the top-level `package.json`
