### PR TITLE
Explicitly specify git diff prefixes

### DIFF
--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -214,6 +214,8 @@ export function makePatch({
       "--no-color",
       "--ignore-space-at-eol",
       "--no-ext-diff",
+      "--src-prefix=a/",
+      "--dst-prefix=b/"
     )
 
     if (diffResult.stdout.length === 0) {


### PR DESCRIPTION
This should resolve #394. Added explicit arguments for src & dst prefixes for `git diff` command.