### PR TITLE
dereference symlink on copying .npmrc and .yarnrc in makePatch

### DIFF
--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -115,7 +115,7 @@ export function makePatch({
     ;[".npmrc", ".yarnrc"].forEach((rcFile) => {
       const rcPath = join(appPath, rcFile)
       if (existsSync(rcPath)) {
-        copySync(rcPath, join(tmpRepo.name, rcFile))
+        copySync(rcPath, join(tmpRepo.name, rcFile), { dereference: true })
       }
     })
 


### PR DESCRIPTION
Our team was facing problem on making patch, in which the package is hosted in private registry. We have noticed that #152 has already handle such scenario, but we are still facing error with message similar as #300 

After checking, we notice that since our `.npmrc` is symlink to somewhere else (as to facilitate switch registry), we use symlink which is copied into the tmp folder during make patch, and thus the symlink cannot resolve. 

This PR uses node fs `copySync` `dereference` flag (https://github.com/jprichardson/node-fs-extra/blob/master/docs/copy-sync.md) to dereference the symlink

Thanks