### PR TITLE
Feature: ignore new files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const argv = minimist(process.argv.slice(2), {
     "version",
     "error-on-fail",
     "create-issue",
+    "ignore-new-files",
   ],
   string: ["patch-dir"],
 })
@@ -60,6 +61,7 @@ if (argv.version || argv.v) {
       argv["use-yarn"] ? "yarn" : null,
     )
     const createIssue = argv["create-issue"]
+    const ignoreNewFiles = argv["ignore-new-files"]
     packageNames.forEach((packagePathSpecifier: string) => {
       makePatch({
         packagePathSpecifier,
@@ -69,6 +71,7 @@ if (argv.version || argv.v) {
         excludePaths,
         patchDir,
         createIssue,
+        ignoreNewFiles,
       })
     })
   } else {
@@ -173,5 +176,13 @@ Usage:
     ${chalk.bold("--patch-dir")}
 
         Specify the name for the directory in which to put the patch files.
+
+    ${chalk.bold("--ignore-new-files")}
+
+        By default, patch-package includes all files present in the package
+        folder. If you specify this option, it will only include changes to
+        files that already existed in the original package. That is useful for
+        example if you linked the patched package with 'npm link', so it also
+        contains source files or build artifacts.
 `)
 }

--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -49,6 +49,7 @@ export function makePatch({
   excludePaths,
   patchDir,
   createIssue,
+  ignoreNewFiles,
 }: {
   packagePathSpecifier: string
   appPath: string
@@ -57,6 +58,7 @@ export function makePatch({
   excludePaths: RegExp
   patchDir: string
   createIssue: boolean
+  ignoreNewFiles: boolean
 }) {
   const packageDetails = getPatchDetailsFromCliString(packagePathSpecifier)
 
@@ -204,8 +206,12 @@ export function makePatch({
     // also remove ignored files like before
     removeIgnoredFiles(tmpRepoPackagePath, includePaths, excludePaths)
 
-    // stage all files
-    git("add", "-f", packageDetails.path)
+    // stage updated/all files
+    if (ignoreNewFiles) {
+      git("add", "-f", "-u", packageDetails.path)
+    } else {
+      git("add", "-f", packageDetails.path)
+    }
 
     // get diff of changes
     const diffResult = git(


### PR DESCRIPTION
_Background:_ I linked my package with `npm link`, which creates a symlink and includes all the source files and everything in the `node_modules` folder, so I was quite surprised to see how large the patch was. Providing this flag therefore seems quite logical for me.

I do not consider this implementation complete - it does what I needed, but I didn't add any tests, and haven't checked how it works together with `--include/exclude` etc. So, maintainers, please provide feedback if this is something you want to add.