### PR TITLE
add —use-npm for a yarn project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import isCi from "is-ci"
 const appPath = getAppRootPath()
 const argv = minimist(process.argv.slice(2), {
   boolean: [
+    "use-npm",
     "use-yarn",
     "case-sensitive-path-filtering",
     "reverse",
@@ -57,7 +58,7 @@ if (argv.version || argv.v) {
     )
     const packageManager = detectPackageManager(
       appPath,
-      argv["use-yarn"] ? "yarn" : null,
+      argv["use-yarn"] ? "yarn" : (argv["use-npm"] ? "npm" : null),
     )
     const createIssue = argv["create-issue"]
     packageNames.forEach((packagePathSpecifier: string) => {


### PR DESCRIPTION
Why:
I know we have copied the `.npmrc` and `.yarnrc` if it is exists in the current project.
But yarn does not respect all settings in the `.yarnrc`, eg. the `registry` settings.

So for a yarn project that need patch, we have to specify the registry settings in a `.npmrc` to make it able to download from private registry.