### PR TITLE
Bump Semver to 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/minimist": "^1.2.2",
     "@types/node": "^12.0.0",
     "@types/rimraf": "^2.0.2",
-    "@types/semver": "^5.5.0",
+    "@types/semver": "^7.0.0",
     "@types/tmp": "^0.0.34",
     "husky": "^1.3.1",
     "jest": "^24.5.0",
@@ -79,7 +79,7 @@
     "minimist": "^1.2.6",
     "open": "^7.4.2",
     "rimraf": "^2.6.3",
-    "semver": "^5.6.0",
+    "semver": "^7.0.0",
     "slash": "^2.0.0",
     "tmp": "^0.0.33",
     "yaml": "^2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -500,10 +500,10 @@
     "@types/glob" "*"
     "@types/node" "*"
 
-"@types/semver@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.5.0.tgz#146c2a29ee7d3bae4bf2fcb274636e264c813c45"
-  integrity sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
+"@types/semver@^7.0.0":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -5014,7 +5014,7 @@ semver-diff@^3.1.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
+semver@^5.4.1, semver@^5.5, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -5023,6 +5023,13 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.0.0:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@^7.3.2, semver@^7.3.4:
   version "7.3.4"


### PR DESCRIPTION
https://github.com/npm/node-semver/blob/main/CHANGELOG.md

Major version change is mainly dropping old node versions.