### PR TITLE
feat: add preliminary support for Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ team.
 
   By default, patch-package checks whether you use npm, yarn or bun based on
   which lockfile you have. If you have multiple lockfiles, it uses npm by
-  default. Set this option to override that default and always use yarn.
+  default (in cases where npm is not available, it will resort to yarn). Set
+  this option to override that default and always use yarn.
 
 - `--use-bun`
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ team.
 
 - `--use-yarn`
 
-  By default, patch-package checks whether you use npm or yarn based on which
-  lockfile you have. If you have both, it uses npm by default. Set this option
-  to override that default and always use yarn.
+  By default, patch-package checks whether you use npm, yarn or bun based on
+  which lockfile you have. If you have multiple lockfiles, it uses npm by
+  default. Set this option to override that default and always use yarn.
 
 - `--exclude <regexp>`
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ team.
 
 - `--use-bun`
 
-  Similar to --use-yarn, but for bun.
+  Similar to --use-yarn, but for bun. If both --use-yarn and --use-bun are
+  specified, --use-yarn takes precedence.
 
 - `--exclude <regexp>`
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ team.
   which lockfile you have. If you have multiple lockfiles, it uses npm by
   default. Set this option to override that default and always use yarn.
 
+- `--use-bun`
+
+  Similar to --use-yarn, but for bun.
+
 - `--exclude <regexp>`
 
   Ignore paths matching the regexp when creating patch files. Paths are relative

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ yarn 2+ have native support for patching dependencies via
 [`yarn patch`](https://yarnpkg.com/cli/patch). You do not need to use
 patch-package on these projects.
 
+### bun
+
+    bun add patch-package
+
+You can use `--dev` if you don't need to run bun in production, e.g. if you're
+making a web frontend.
+
 ### pnpm
 
 pnpm has native support for patching dependencies via

--- a/src/detectPackageManager.ts
+++ b/src/detectPackageManager.ts
@@ -48,7 +48,7 @@ export const detectPackageManager = (
     join(appRootPath, "npm-shrinkwrap.json"),
   )
   const yarnLockExists = fs.existsSync(
-    join(findWorkspaceRoot() ?? appRootPath, "pnpm-lock.yaml"),
+    join(findWorkspaceRoot() ?? appRootPath, "yarn.lock"),
   )
   // Bun workspaces seem to work the same as yarn workspaces - https://bun.sh/docs/install/workspaces
   const bunLockbExists = fs.existsSync(

--- a/src/detectPackageManager.ts
+++ b/src/detectPackageManager.ts
@@ -45,6 +45,18 @@ deleting the conflicting lockfile if you don't need it
   )
 }
 
+function printSelectingDefaultYarnMessage() {
+  console.info(
+    `${chalk.bold(
+      "patch-package",
+    )}: you have both yarn.lock and bun.lockb lockfiles
+Defaulting to using ${chalk.bold("yarn")}
+You can override this setting by passing --use-bun, or
+deleting yarn.lock if you don't need it
+`,
+  )
+}
+
 function checkForYarnOverride(overridePackageManager: PackageManager | null) {
   if (overridePackageManager === "yarn") {
     printNoYarnLockfileError()
@@ -85,6 +97,11 @@ export const detectPackageManager = (
   ) {
     if (overridePackageManager) {
       return overridePackageManager
+    }
+    if (!packageLockExists && !shrinkWrapExists) {
+      // The only case where we don't want to default to npm is when we have both yarn and bun lockfiles.
+      printSelectingDefaultYarnMessage()
+      return "yarn"
     }
     printSelectingDefaultMessage()
     return shrinkWrapExists ? "npm-shrinkwrap" : "npm"

--- a/src/detectPackageManager.ts
+++ b/src/detectPackageManager.ts
@@ -77,7 +77,12 @@ export const detectPackageManager = (
   } else if (yarnLockExists) {
     return "yarn"
   } else if (bunLockbExists) {
-    return "bun"
+    if (overridePackageManager === "yarn") {
+      printNoYarnLockfileError()
+      process.exit(1)
+    } else {
+      return "bun"
+    }
   } else {
     printNoLockfilesError()
     process.exit(1)

--- a/src/detectPackageManager.ts
+++ b/src/detectPackageManager.ts
@@ -29,7 +29,7 @@ function printSelectingDefaultMessage() {
   console.info(
     `${chalk.bold(
       "patch-package",
-    )}: you have both yarn.lock and package-lock.json
+    )}: you have multiple lockfiles, e.g. yarn.lock and package-lock.json
 Defaulting to using ${chalk.bold("npm")}
 You can override this setting by passing --use-yarn or deleting
 package-lock.json if you don't need it
@@ -54,7 +54,13 @@ export const detectPackageManager = (
   const bunLockbExists = fs.existsSync(
     join(findWorkspaceRoot() ?? appRootPath, "bun.lockb"),
   )
-  if ((packageLockExists || shrinkWrapExists) && yarnLockExists) {
+  if (
+    [
+      packageLockExists || shrinkWrapExists,
+      yarnLockExists,
+      bunLockbExists,
+    ].filter(Boolean).length > 1
+  ) {
     if (overridePackageManager) {
       return overridePackageManager
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,8 @@ Usage:
 
         By default, patch-package checks whether you use npm, yarn or bun based on
         which lockfile you have. If you have multiple lockfiles, it uses npm by
-        default. Set this option to override that default and always use yarn.
+        default (in cases where npm is not available, it will resort to yarn). Set 
+        this option to override that default and always use yarn.
         
     ${chalk.bold("--use-bun")}
     

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ if (argv.version || argv.v) {
     )
     const packageManager = detectPackageManager(
       appPath,
-      argv["use-yarn"] ? "yarn" : null,
+      argv["use-yarn"] ? "yarn" : argv["use-bun"] ? "bun" : null,
     )
     const createIssue = argv["create-issue"]
     packageNames.forEach((packagePathSpecifier: string) => {
@@ -198,9 +198,13 @@ Usage:
 
     ${chalk.bold("--use-yarn")}
 
-        By default, patch-package checks whether you use npm or yarn based on
-        which lockfile you have. If you have both, it uses npm by default.
-        Set this option to override that default and always use yarn.
+        By default, patch-package checks whether you use npm, yarn or bun based on
+        which lockfile you have. If you have multiple lockfiles, it uses npm by
+        default. Set this option to override that default and always use yarn.
+        
+    ${chalk.bold("--use-bun")}
+    
+        Similar to --use-yarn, but for bun.
 
     ${chalk.bold("--exclude <regexp>")}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,7 +204,8 @@ Usage:
         
     ${chalk.bold("--use-bun")}
     
-        Similar to --use-yarn, but for bun.
+        Similar to --use-yarn, but for bun. If both --use-yarn and --use-bun are
+        specified, --use-yarn takes precedence.
 
     ${chalk.bold("--exclude <regexp>")}
 

--- a/src/parseBunLockfile.ts
+++ b/src/parseBunLockfile.ts
@@ -1,0 +1,15 @@
+import { spawnSync } from "child_process"
+
+// From https://github.com/oven-sh/bun/blob/ffe4f561a3af53b9f5a41c182de55d7199b5d692/packages/bun-vscode/src/features/lockfile.ts#L39,
+// rewritten to use spawnSync instead of spawn.
+export function parseBunLockfile(lockFilePath: string): string {
+  const process = spawnSync("bun", [lockFilePath], {
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  if (process.status !== 0) {
+    throw new Error(
+      `Bun exited with code: ${process.status}\n${process.stderr.toString()}`,
+    )
+  }
+  return process.stdout.toString()
+}

--- a/src/parseBunLockfile.ts
+++ b/src/parseBunLockfile.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "child_process"
 
-// From https://github.com/oven-sh/bun/blob/ffe4f561a3af53b9f5a41c182de55d7199b5d692/packages/bun-vscode/src/features/lockfile.ts#L39,
+// Adapted from https://github.com/oven-sh/bun/blob/ffe4f561a3af53b9f5a41c182de55d7199b5d692/packages/bun-vscode/src/features/lockfile.ts#L39,
 // rewritten to use spawnSync instead of spawn.
 export function parseBunLockfile(lockFilePath: string): string {
   const process = spawnSync("bun", [lockFilePath], {


### PR DESCRIPTION
Closes #489. 

**Changelogs:**
- Added `--use-bun` flag, similar to the current `--use-yarn` flag.
- Added `parseBunLockfile.ts` to convert bun.lockb into yarn v1 lockfiles.
- Updated `getPackageResolution.ts` to handle bun conversions before parsing.
- Updated `detectPackageManager.ts` to detect bun, bun workspaces and multiple lockfiles. 
- Updated README with setup instructions for Bun.

**Caveats:** 
- If user has multiple lockfiles, patch-package uses npm by default. However, in the rare case where only bun.lockb and yarn.lock files exist, we have to resort to using yarn. This behaviour has been documented in the CLI and README (see https://github.com/ds300/patch-package/pull/490/commits/0491b915e20e9e5305c336ae565098bef608c9b5).
- ~~Currently awaiting confirmation on how Bun handles postinstalls, for writing up the README about bun setup. (Will `bun remove` execute postinstall scripts? If not, bun users should also install `postinstall-postinstall` just like yarn v1 users.)~~ 
  - Confirmed by https://github.com/ds300/patch-package/pull/490#issuecomment-1712882619.
  - Fixed by https://github.com/ds300/patch-package/pull/490/commits/7482db96c1a4e59c3ecace0409330e0c24b125a7.
- Currently awaiting confirmation on how Bun workspaces work, for writing up the README about bun workspaces setup (Is it similar to yarn workspaces, where users need to "repeat the setup process for the child package" if they want to patch un-hoisted packages?)

**Temporary workaround (while this PR is unmerged):**
- Citing https://github.com/oven-sh/bun/issues/2336#issuecomment-1712458657,
  > Attempting to create a patch using `bunx patch-package <package-name>` fails. 
  > 
  > However, if you have pre-existing patches in the `./patches` directory, you can successfully apply them using the `bunx patch-package` command (or via package.json -> scripts -> `"postinstall": "patch-package"`)
  > 
  > As a temporary workaround to generate a `patches/package+name+version.patch` file
  > * run [`bun install --yarn`](https://bun.sh/docs/install/lockfile) _it just converts bun.lockb into a yarn.lock_. (or `bun ./bun.lockb > ./yarn.lock`)
  > * make the necessary modifications inside `node-modules/<package-name>`
  > * `bunx patch-package <package-name>`
  > * `rm yarn.lock`
  > * package.json -> scripts -> `"postinstall": "bunx patch-package"`
  >   https://github.com/ds300/patch-package
