### PR TITLE
bugfix: do not sign temporary commit when creating patch file

### DIFF
--- a/src/makePatch.ts
+++ b/src/makePatch.ts
@@ -267,6 +267,9 @@ export function makePatch({
     git("config", "--local", "user.name", "patch-package")
     git("config", "--local", "user.email", "patch@pack.age")
 
+    // installed git could be configured to always sign, so override that just in case
+    git("config", "--local", "commit.gpgsign", "false")
+
     // remove ignored files first
     removeIgnoredFiles(tmpRepoPackagePath, includePaths, excludePaths)
 


### PR DESCRIPTION
Closes #456 and #353 by overriding commit settings when creating patch files