### PR TITLE
Add support for npm workspaces

### DIFF
--- a/src/PackageDetails.ts
+++ b/src/PackageDetails.ts
@@ -4,6 +4,7 @@ export interface PackageDetails {
   humanReadablePathSpecifier: string
   pathSpecifier: string
   path: string
+  workspacePath?: string
   name: string
   isNested: boolean
   packageNames: string[]


### PR DESCRIPTION
I noticed that patch-package didn't work in npm workspaces and came up with this patch. I can get it fixed up and tested if you are interested in landing this. It works slightly different than yarn works. You just treat the workspace like any other nested dependency from the top level. It seems to work fine, but maybe there is a justified reason for requiring patches be made IN the workspace and resolving up to the lock file the way yarn does it. Happy to accommodate if thats preferred. 