### PR TITLE
fix: correctly resolve the installed package version

### DIFF
--- a/src/getPackageResolution.ts
+++ b/src/getPackageResolution.ts
@@ -60,7 +60,7 @@ export function getPackageResolution({
 
     const resolutions = entries.map(([_, v]) => {
       // @ts-ignore
-      return v.resolved
+      return v.resolved || v.version
     })
 
     if (resolutions.length === 0) {


### PR DESCRIPTION
## Issue
In our project, the `react-native-web` lib is referenced at two places and the respective version scheme for it is different, one is the `^0.19.12`, another is the `~0.19.12`, after installing by the `yarn` command, the final `yarn.lock` file includes such a fragment which describes what version of the `react-native-web` we're using, but the `patch-package` seems to be not able to correctly process this kind of structure, finally it resolves the package version to be the `^0.19.12, react-native-web@npm:~0.19.12`, apparently, it's incorrect and causes the patch procedure to fail.
<img width="1253" alt="image" src="https://github.com/user-attachments/assets/77197e6a-bb1c-469a-a5f6-472eabd9735a">

## Environment
- Package manager: Yarn
