### PR TITLE
Don't warn about multiple patches 

### DIFF
--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -270,15 +270,19 @@ export function applyPatchesForPackage({
         // yay patch was applied successfully
         // print warning if version mismatch
         if (installedPackageVersion !== version) {
-          warnings.push(
-            createVersionMismatchWarning({
-              packageName: name,
-              actualVersion: installedPackageVersion,
-              originalVersion: version,
-              pathSpecifier,
-              path,
-            }),
-          )
+          if (version.includes('+') && version.split('+')[0] === installedPackageVersion) {
+            console.log("Ignoring multi-patch version mismatch for", pathSpecifier);
+          } else {
+            warnings.push(
+              createVersionMismatchWarning({
+                packageName: name,
+                actualVersion: installedPackageVersion,
+                originalVersion: version,
+                pathSpecifier,
+                path,
+              }),
+            )
+          }
         }
         logPatchApplication(patchDetails)
       } else if (patches.length > 1) {

--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -270,8 +270,11 @@ export function applyPatchesForPackage({
         // yay patch was applied successfully
         // print warning if version mismatch
         if (installedPackageVersion !== version) {
-          if (version.includes('+') && version.split('+')[0] === installedPackageVersion) {
-            console.log("Ignoring multi-patch version mismatch for", pathSpecifier);
+          if (
+            version.includes("+") &&
+            version.split("+")[0] === installedPackageVersion
+          ) {
+            console.log("Multiple patch version matches for", pathSpecifier)
           } else {
             warnings.push(
               createVersionMismatchWarning({


### PR DESCRIPTION
Resolves #541 

When using multiple patches, we see errors when multiple patches are applied to the same library. This is because the version numbers are compared without consideration for the suffix.

This PR adds a check to skip the warning. This is useful when using the `--error-on-warn` flag.

```
Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    axios@1.7.7+lowercase

  applied to

    axios@1.7.7

  At path

    node_modules/axios

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package axios

  to update the version in the patch file name and make this warning go away.


Warning: patch-package detected a patch file version mismatch

  Don't worry! This is probably fine. The patch was still applied
  successfully. Here's the deets:

  Patch file created for

    axios@1.7.7+status-missing

  applied to

    axios@1.7.7

  At path

    node_modules/axios

  This warning is just to give you a heads-up. There is a small chance of
  breakage even though the patch was applied successfully. Make sure the package
  still behaves like you expect (you wrote tests, right?) and then run

    patch-package axios

  to update the version in the patch file name and make this warning go away.

---
patch-package finished with 2 warning(s).
```