### PR TITLE
fix: use loose semver to eliminate unnecessary errors

### DIFF
--- a/src/applyPatches.ts
+++ b/src/applyPatches.ts
@@ -62,7 +62,7 @@ function getInstalledPackageVersion({
 
   const { version } = require(join(packageDir, "package.json"))
   // normalize version for `npm ci`
-  const result = semver.valid(version)
+  const result = semver.valid(version, { loose: true })
   if (result === null) {
     throw new PatchApplicationError(
       `${chalk.red(


### PR DESCRIPTION
I recently used patch-package in production, and I got the “Version string cannot be parsed” error because one of my npm packages had the version 0.10.1a in its package.json. The ‘a’ at the end was causing the error. As a result, patch-package was unable to patch this npm package when doing a fresh npm install and postinstall. To keep patch-package simple to use, I think this is a great change that covers slightly irregular npm package syntax