### PR TITLE
chore: standardize shebang format

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 require("./dist/index.js")


### PR DESCRIPTION
This shebang contains an extra space, which is non-standard and may not be recognized correctly on some platforms. To improve compatibility, I've removed the space.